### PR TITLE
Reinitialize Sphinx to set up the necessary files in the source directory

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -75,6 +75,21 @@ sphinx-build -b html sourcedir builddir
 
 This will generate the HTML documentation in the `builddir` directory. You can then open the generated HTML files in your web browser to view the documentation.
 
+Reinitializing Sphinx
+----------------------
+
+If you need to reinitialize Sphinx to set up the necessary files in the source directory, follow these steps:
+
+1. Delete the existing `docs` directory or move it to a backup location.
+2. Run the `sphinx-quickstart` command again to create a new documentation project:
+
+```bash
+sphinx-quickstart
+```
+
+3. Configure your `conf.py` file to use Sphinxus and any other extensions you need.
+4. Rebuild the documentation using the `sphinx-build` command.
+
 Next Steps
 ----------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,3 +15,6 @@ Welcome to the Sphinxus documentation! This documentation will help you understa
    getting_started
    faq
    changelog
+   api_reference
+   configuration
+   troubleshooting

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,3 +24,18 @@ extensions = [
     # other extensions
 ]
 ```
+
+Reinitializing Sphinx
+----------------------
+
+If you need to reinitialize Sphinx to set up the necessary files in the source directory, follow these steps:
+
+1. Delete the existing `docs` directory or move it to a backup location.
+2. Run the `sphinx-quickstart` command again to create a new documentation project:
+
+```bash
+sphinx-quickstart
+```
+
+3. Configure your `conf.py` file to use Sphinxus and any other extensions you need.
+4. Rebuild the documentation using the `sphinx-build` command.


### PR DESCRIPTION
Reinitialize Sphinx to set up the necessary files in the source directory.

* Update `docs/index.rst` to include additional sections in the table of contents: `api_reference`, `configuration`, and `troubleshooting`.
* Add a section in `docs/getting_started.rst` to provide steps for reinitializing Sphinx, including deleting the existing `docs` directory, running `sphinx-quickstart`, configuring `conf.py`, and rebuilding the documentation.
* Add a section in `docs/installation.rst` to provide steps for reinitializing Sphinx, similar to the steps added in `docs/getting_started.rst`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/sphinxus?shareId=34d73a10-9c1f-466a-9914-1fc26eb61809).